### PR TITLE
refactor: main sync guardをedit/createのみdenyに簡素化

### DIFF
--- a/scripts/main_sync_guard_lib.sh
+++ b/scripts/main_sync_guard_lib.sh
@@ -145,95 +145,15 @@ is_main_sync_blocked_status() {
   esac
 }
 
-is_main_sync_mutating_tool() {
+is_main_sync_denied_tool() {
   case "$1" in
-    apply_patch | bash | create | edit | multiEdit | stop_bash | task | write | write_bash)
+    edit | create)
       return 0
       ;;
     *)
       return 1
       ;;
   esac
-}
-
-trim_main_sync_shell_text() {
-  local value="$1"
-
-  value="${value#"${value%%[![:space:]]*}"}"
-  value="${value%"${value##*[![:space:]]}"}"
-  printf '%s' "$value"
-}
-
-is_main_sync_safe_shell_segment() {
-  local segment
-
-  segment="$(trim_main_sync_shell_text "$1")"
-  if [ -z "$segment" ]; then
-    return 0
-  fi
-
-  case "$segment" in
-    *'|'* | *';'* | *'>'* | *'<'* | *'`'* | *'$('* | *'${'*)
-      return 1
-      ;;
-  esac
-
-  case "$segment" in
-    git\ fetch* | git\ status* | git\ branch* | git\ log* | git\ diff* | git\ rev-parse* | git\ merge-base*)
-      return 0
-      ;;
-    git\ pull*)
-      return 0
-      ;;
-    git\ rebase\ *origin/main* | git\ merge\ *origin/main*)
-      return 0
-      ;;
-    *)
-      return 1
-      ;;
-  esac
-}
-
-is_main_sync_allowed_shell_command() {
-  local command="$1"
-  local remaining segment without_double_and
-
-  command="$(trim_main_sync_shell_text "$command")"
-  if [ -z "$command" ]; then
-    return 1
-  fi
-
-  case "$command" in
-    *$'\n'* | *'||'*)
-      return 1
-      ;;
-  esac
-
-  without_double_and="${command//&&/}"
-  case "$without_double_and" in
-    *'&'*)
-      return 1
-      ;;
-  esac
-
-  remaining="$command"
-  while :; do
-    if [[ "$remaining" == *"&&"* ]]; then
-      segment="${remaining%%&&*}"
-      remaining="${remaining#*&&}"
-    else
-      segment="$remaining"
-      remaining=""
-    fi
-
-    if ! is_main_sync_safe_shell_segment "$segment"; then
-      return 1
-    fi
-
-    if [ -z "$remaining" ]; then
-      return 0
-    fi
-  done
 }
 
 main_sync_resolution_message() {

--- a/scripts/pre_tool_use_main_sync.sh
+++ b/scripts/pre_tool_use_main_sync.sh
@@ -11,14 +11,6 @@ ensure_main_sync_jq
 input="$(cat)"
 cwd="$(printf '%s' "$input" | jq -r '.cwd // empty')"
 tool_name="$(printf '%s' "$input" | jq -r '.toolName // .tool // empty')"
-tool_args_json="$(printf '%s' "$input" | jq -c '
-  (.toolArgs // .args // {})
-  | if type == "string" then
-      (try fromjson catch .)
-    else
-      .
-    end
-')"
 
 if [ -z "$cwd" ] || [ ! -d "$cwd" ]; then
   echo "main sync guard の実行ディレクトリが不正です: $cwd" >&2
@@ -41,22 +33,8 @@ if ! is_main_sync_blocked_status "$status"; then
   exit 0
 fi
 
-if ! is_main_sync_mutating_tool "$tool_name"; then
+if ! is_main_sync_denied_tool "$tool_name"; then
   exit 0
-fi
-
-if [ "$tool_name" = "bash" ]; then
-  shell_command="$(printf '%s' "$tool_args_json" | jq -r '
-    if type == "object" then
-      .command // empty
-    else
-      empty
-    end
-  ')"
-
-  if is_main_sync_allowed_shell_command "$shell_command"; then
-    exit 0
-  fi
 fi
 
 reason="$(main_sync_resolution_message "$status")"

--- a/tests/test_pre_tool_use_main_sync.py
+++ b/tests/test_pre_tool_use_main_sync.py
@@ -29,7 +29,7 @@ class TestPreToolUseMainSync:
         state = _read_main_sync_state(tmp_path)
         assert state["status"] == "up_to_date"
 
-    def test_正常系_stateがup_to_dateでもfetch後なら再計算してdenyする(
+    def test_正常系_stateがup_to_dateでもfetch後なら再計算して許可する(
         self, tmp_path: Path
     ) -> None:
         result = _run_pre_hook_with_fake_git(
@@ -46,9 +46,7 @@ class TestPreToolUseMainSync:
         )
 
         assert result.returncode == 0
-        response = json.loads(result.stdout)
-        assert response["permissionDecision"] == "deny"
-        assert "git rebase origin/main" in response["permissionDecisionReason"]
+        assert result.stdout == ""
         state = _read_main_sync_state(tmp_path)
         assert state["status"] == "behind_main"
 

--- a/tests/test_pre_tool_use_main_sync.py
+++ b/tests/test_pre_tool_use_main_sync.py
@@ -65,15 +65,17 @@ class TestPreToolUseMainSync:
         assert result.returncode == 0
         assert result.stdout == ""
 
-    def test_異常系_behind_mainで編集系操作をdenyする(self, tmp_path: Path) -> None:
+    def test_異常系_behind_mainでeditをdenyする(self, tmp_path: Path) -> None:
         _write_main_sync_state(tmp_path, status="behind_main")
 
         result = _run_pre_hook(
             tmp_path=tmp_path,
             payload={
                 "cwd": str(tmp_path),
-                "toolName": "apply_patch",
-                "toolArgs": "*** Begin Patch\n*** End Patch\n",
+                "toolName": "edit",
+                "toolArgs": json.dumps(
+                    {"path": "README.md", "old_string": "before", "new_string": "after"}
+                ),
             },
         )
 
@@ -97,39 +99,7 @@ class TestPreToolUseMainSync:
         assert result.returncode == 0
         assert result.stdout == ""
 
-    def test_正常系_behind_mainでもgit_fetchは許可する(self, tmp_path: Path) -> None:
-        _write_main_sync_state(tmp_path, status="behind_main")
-
-        result = _run_pre_hook(
-            tmp_path=tmp_path,
-            payload={
-                "cwd": str(tmp_path),
-                "toolName": "bash",
-                "toolArgs": json.dumps({"command": "git fetch origin main --quiet"}),
-            },
-        )
-
-        assert result.returncode == 0
-        assert result.stdout == ""
-
-    def test_正常系_behind_mainでもgit_pull_ff_onlyは許可する(
-        self, tmp_path: Path
-    ) -> None:
-        _write_main_sync_state(tmp_path, status="behind_main")
-
-        result = _run_pre_hook(
-            tmp_path=tmp_path,
-            payload={
-                "cwd": str(tmp_path),
-                "toolName": "bash",
-                "toolArgs": json.dumps({"command": "git pull --ff-only"}),
-            },
-        )
-
-        assert result.returncode == 0
-        assert result.stdout == ""
-
-    def test_異常系_behind_mainでは更新系bashをdenyする(self, tmp_path: Path) -> None:
+    def test_正常系_behind_mainでもbashは許可する(self, tmp_path: Path) -> None:
         _write_main_sync_state(tmp_path, status="behind_main")
 
         result = _run_pre_hook(
@@ -142,9 +112,37 @@ class TestPreToolUseMainSync:
         )
 
         assert result.returncode == 0
-        response = json.loads(result.stdout)
-        assert response["permissionDecision"] == "deny"
-        assert "git rebase origin/main" in response["permissionDecisionReason"]
+        assert result.stdout == ""
+
+    def test_正常系_behind_mainでもtaskは許可する(self, tmp_path: Path) -> None:
+        _write_main_sync_state(tmp_path, status="behind_main")
+
+        result = _run_pre_hook(
+            tmp_path=tmp_path,
+            payload={
+                "cwd": str(tmp_path),
+                "toolName": "task",
+                "toolArgs": json.dumps({"agent_type": "general-purpose"}),
+            },
+        )
+
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    def test_正常系_behind_mainでもwrite_bashは許可する(self, tmp_path: Path) -> None:
+        _write_main_sync_state(tmp_path, status="behind_main")
+
+        result = _run_pre_hook(
+            tmp_path=tmp_path,
+            payload={
+                "cwd": str(tmp_path),
+                "toolName": "write_bash",
+                "toolArgs": json.dumps({"shellId": "shell-1", "input": "continue"}),
+            },
+        )
+
+        assert result.returncode == 0
+        assert result.stdout == ""
 
     def test_正常系_ahead_of_mainならbashを許可する(self, tmp_path: Path) -> None:
         _write_main_sync_state(tmp_path, status="ahead_of_main")
@@ -161,15 +159,34 @@ class TestPreToolUseMainSync:
         assert result.returncode == 0
         assert result.stdout == ""
 
-    def test_異常系_divergedでも編集系操作をdenyする(self, tmp_path: Path) -> None:
+    def test_異常系_behind_mainでcreateをdenyする(self, tmp_path: Path) -> None:
+        _write_main_sync_state(tmp_path, status="behind_main")
+
+        result = _run_pre_hook(
+            tmp_path=tmp_path,
+            payload={
+                "cwd": str(tmp_path),
+                "toolName": "create",
+                "toolArgs": json.dumps({"path": "new_file.txt", "content": "hello"}),
+            },
+        )
+
+        assert result.returncode == 0
+        response = json.loads(result.stdout)
+        assert response["permissionDecision"] == "deny"
+        assert "git rebase origin/main" in response["permissionDecisionReason"]
+
+    def test_異常系_divergedでもeditをdenyする(self, tmp_path: Path) -> None:
         _write_main_sync_state(tmp_path, status="diverged")
 
         result = _run_pre_hook(
             tmp_path=tmp_path,
             payload={
                 "cwd": str(tmp_path),
-                "toolName": "bash",
-                "toolArgs": json.dumps({"command": "pytest"}),
+                "toolName": "edit",
+                "toolArgs": json.dumps(
+                    {"path": "README.md", "old_string": "before", "new_string": "after"}
+                ),
             },
         )
 


### PR DESCRIPTION
## 概要

fictional-scientists の [PR #56](https://github.com/jiroshimaya/fictional-scientists/pull/56) と同じ方針で、main sync guard を `edit` / `create` だけ deny する実装へ簡素化しました。

## 変更内容

- `scripts/main_sync_guard_lib.sh`
  - deny 判定を `is_main_sync_denied_tool()` に置き換え
  - bash コマンド許可判定の補助関数群を削除
- `scripts/pre_tool_use_main_sync.sh`
  - `toolArgs` 解析を削除
  - blocked 時は `edit` / `create` のみ deny するよう変更
- `tests/test_pre_tool_use_main_sync.py`
  - `edit` / `create` を deny するテストへ更新
  - `bash` / `task` / `write_bash` が許可されることを確認

## テスト

```bash
uv run task check
```
